### PR TITLE
修复路书先暂停再开始出现的异常情况

### DIFF
--- a/src/LuShu/LuShu.js
+++ b/src/LuShu/LuShu.js
@@ -244,11 +244,13 @@ var BMapLib = window.BMapLib = BMapLib || {};
             //没按pause再按start不做处理
             if (!me._fromPause) {
                 return;
-            }else if(!me._fromStop){
-	            //按了pause按钮,并且再按start，直接移动到下一点
+            }else if(!me._fromStop) {
+                //按了pause按钮,并且再按start，从原位置开始继续移动
 	            //并且此过程中，没有按stop按钮
 	            //防止先stop，再pause，然后连续不停的start的异常
-	            me._moveNext(++me.i);
+	            var current = me._marker.getPosition();
+                var next = me._path[me.i + 1];
+                me._move(current, next, me._tween.linear);
             }
         }else {
             //第一次点击开始，或者点了stop之后点开始

--- a/src/LuShu/LuShu.js
+++ b/src/LuShu/LuShu.js
@@ -240,7 +240,7 @@ var BMapLib = window.BMapLib = BMapLib || {};
         var me = this,
             len = me._path.length;
         //不是第一次点击开始,并且小车还没到达终点
-        if (me.i && me.i < len - 1) {
+        if (me.i != -1 && me.i < len - 1) {
             //没按pause再按start不做处理
             if (!me._fromPause) {
                 return;
@@ -254,6 +254,7 @@ var BMapLib = window.BMapLib = BMapLib || {};
             }
         }else {
             //第一次点击开始，或者点了stop之后点开始
+            me.i = 0;
             me._addMarker();
             //等待marker动画完毕再加载infowindow
             me._timeoutFlag = setTimeout(function() {
@@ -276,7 +277,7 @@ var BMapLib = window.BMapLib = BMapLib || {};
      * lushu.stop();
      */
     LuShu.prototype.stop = function() {
-        this.i = 0;
+        this.i = -1;
         this._fromStop = true;
         clearInterval(this._intervalFlag);
         this._clearTimeout();


### PR DESCRIPTION
当两个坐标点相距较远时，暂停再开始会出现如下情况：
1. 暂停再开始直接跳到下一个点开始显得突兀；
2. 在起始点和第二个点间暂停再开始会重新从起始点开始移动；
3. 在倒数第二个点与倒数第一个点暂停时无法再继续移动。

复现与测试：
1. 替换密钥以复现上述情况；
2. 替换本次修改后的 LuShu.js 以验证此次修复。

[lushu_test.zip](https://github.com/huiyan-fe/BMap-JavaScript-library/files/6747618/lushu_test.zip)
